### PR TITLE
remove duplicate link in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Travis](https://img.shields.io/travis/devinus/poison.svg?style=flat-square)](https://travis-ci.org/devinus/poison)
 [![Hex.pm](https://img.shields.io/hexpm/v/poison.svg?style=flat-square)](https://hex.pm/packages/poison)
-[![Hex.pm](https://img.shields.io/hexpm/dt/poison.svg?style=flat-square)](https://hex.pm/packages/poison)
 [![Gratipay](https://img.shields.io/gratipay/devinus.svg?style=flat-square)](https://gratipay.com/devinus)
 
 Poison is a new JSON library for Elixir focusing on wicked-fast **speed**


### PR DESCRIPTION
The two links there prior, while slightly different, both resolved to `https://hex.pm/packages/poison`. I figured one may as well go.
